### PR TITLE
Corriger les avertissements mongodb

### DIFF
--- a/bot/scripts/seed.js
+++ b/bot/scripts/seed.js
@@ -187,10 +187,7 @@ const defaultConfig = {
 
 const connectDB = async () => {
   try {
-    await mongoose.connect(process.env.MONGODB_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    });
+    await mongoose.connect(process.env.MONGODB_URI);
     console.log('✅ MongoDB connecté');
   } catch (error) {
     console.error('❌ Erreur connexion MongoDB:', error);

--- a/bot/src/utils/database.js
+++ b/bot/src/utils/database.js
@@ -9,10 +9,7 @@ const connectDB = async () => {
   }
 
   try {
-    const connection = await mongoose.connect(process.env.MONGODB_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    });
+    const connection = await mongoose.connect(process.env.MONGODB_URI);
 
     isConnected = true;
     console.log(`✅ MongoDB connecté: ${connection.connection.host}`);


### PR DESCRIPTION
Remove deprecated MongoDB connection options (`useNewUrlParser`, `useUnifiedTopology`) to eliminate warnings.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-0ab7b0ea-8149-4584-a985-9c8a31b8b3a7) · [Cursor](https://cursor.com/background-agent?bcId=bc-0ab7b0ea-8149-4584-a985-9c8a31b8b3a7)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)