### PR TITLE
Corriger l'erreur de texte de message

### DIFF
--- a/bot/src/handlers/startHandler.js
+++ b/bot/src/handlers/startHandler.js
@@ -81,18 +81,57 @@ const handleBackMain = async (ctx) => {
     
     console.log('📝 Message d\'accueil préparé pour le retour');
     
-    // Utiliser editMessageText pour une navigation fluide
-    await ctx.editMessageText(welcomeMessage, {
-      reply_markup: keyboard.reply_markup,
-      parse_mode: 'HTML'
-    });
+    // Vérifier le type de message et agir en conséquence
+    try {
+      // Essayer d'abord d'éditer le message texte
+      await ctx.editMessageText(welcomeMessage, {
+        reply_markup: keyboard.reply_markup,
+        parse_mode: 'HTML'
+      });
+      console.log('✅ Message texte édité avec succès');
+    } catch (editError) {
+      console.log('⚠️ Impossible d\'éditer le message (probablement une photo), suppression et envoi d\'un nouveau message');
+      
+      try {
+        // Supprimer le message actuel
+        await ctx.deleteMessage();
+        console.log('🗑️ Message précédent supprimé');
+      } catch (deleteError) {
+        console.log('⚠️ Impossible de supprimer le message précédent:', deleteError.message);
+      }
+      
+      // Envoyer un nouveau message
+      const welcomeImage = config.welcome?.image || null;
+      
+      if (welcomeImage) {
+        try {
+          console.log('📸 Envoi nouveau message avec image');
+          await ctx.replyWithPhoto(welcomeImage, {
+            caption: welcomeMessage,
+            reply_markup: keyboard.reply_markup,
+            parse_mode: 'HTML'
+          });
+          console.log('✅ Nouveau message avec image envoyé');
+        } catch (photoError) {
+          console.error('❌ Erreur envoi photo, fallback vers texte:', photoError);
+          await ctx.reply(welcomeMessage, keyboard);
+        }
+      } else {
+        console.log('📝 Envoi nouveau message texte');
+        await ctx.reply(welcomeMessage, keyboard);
+      }
+    }
     
     console.log('✅ Retour au menu principal terminé');
     await ctx.answerCbQuery();
   } catch (error) {
     console.error('❌ Erreur dans handleBackMain:', error);
     // Fallback : répondre avec le message de démarrage
-    await ctx.answerCbQuery('❌ Erreur lors du retour au menu');
+    try {
+      await ctx.answerCbQuery('❌ Erreur lors du retour au menu');
+    } catch (cbError) {
+      console.error('❌ Erreur lors de answerCbQuery:', cbError);
+    }
   }
 };
 


### PR DESCRIPTION
Fix 'Bad Request: no text to edit' error when returning to main menu by handling photo messages.

The `handleBackMain` function previously assumed the message could always be edited as text. However, if the initial welcome message was sent with a photo (`replyWithPhoto`), `editMessageText` would fail. This PR introduces a robust fallback: it attempts to edit, and if that fails (indicating a non-editable message type), it deletes the old message and sends a new one, correctly preserving the welcome image if configured.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-41e05b13-443d-464d-890a-237e3a058c1e) · [Cursor](https://cursor.com/background-agent?bcId=bc-41e05b13-443d-464d-890a-237e3a058c1e)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)