### PR TITLE
Fiabiliser édition messages bot

### DIFF
--- a/bot/src/handlers/plugsHandler.js
+++ b/bot/src/handlers/plugsHandler.js
@@ -226,27 +226,24 @@ const handleFilterService = async (ctx) => {
     
     const messageText = `${config?.botTexts?.filterServiceTitle || '🔍 Filtrer par service'}\n\n${config?.botTexts?.filterServiceDescription || 'Choisissez le type de service :'}\n\n📊 **Disponibilité :**\n🚚 Livraison: ${deliveryCount} boutiques\n✈️ Postal: ${postalCount} boutiques\n🏠 Meetup: ${meetupCount} boutiques`;
     
-    if (config?.welcome?.image) {
-      try {
-        await ctx.editMessageMedia({
-          type: 'photo',
-          media: config.welcome.image,
-          caption: messageText,
-          parse_mode: 'Markdown'
-        }, {
-          reply_markup: keyboard.reply_markup
-        });
-      } catch (error) {
-        await ctx.editMessageText(messageText, {
-          reply_markup: keyboard.reply_markup,
-          parse_mode: 'Markdown'
-        });
-      }
-    } else {
+    // Toujours envoyer en texte pour éviter les erreurs d'images
+    try {
       await ctx.editMessageText(messageText, {
         reply_markup: keyboard.reply_markup,
         parse_mode: 'Markdown'
       });
+    } catch (editError) {
+      // Si impossible d'éditer (ex: message avec photo), supprimer et envoyer nouveau
+      try {
+        await ctx.deleteMessage();
+        await ctx.reply(messageText, {
+          reply_markup: keyboard.reply_markup,
+          parse_mode: 'Markdown'
+        });
+      } catch (deleteError) {
+        console.error('Erreur dans handler:', deleteError);
+        await ctx.answerCbQuery('❌ Erreur lors du chargement');
+      }
     }
     
     // Confirmer la callback pour éviter le loading
@@ -341,27 +338,24 @@ const handleFilterCountry = async (ctx) => {
     const config = await Config.findById('main');
     const messageText = `${config.botTexts?.filterCountryTitle || '🌍 Filtrer par pays'}\n\n${config.botTexts?.filterCountryDescription || 'Choisissez un pays :'}`;
     
-    if (config.welcome?.image) {
-      try {
-        await ctx.editMessageMedia({
-          type: 'photo',
-          media: config.welcome.image,
-          caption: messageText,
-          parse_mode: 'Markdown'
-        }, {
-          reply_markup: keyboard.reply_markup
-        });
-      } catch (error) {
-        await ctx.editMessageText(messageText, {
-          reply_markup: keyboard.reply_markup,
-          parse_mode: 'Markdown'
-        });
-      }
-    } else {
+    // Toujours envoyer en texte pour éviter les erreurs d'images
+    try {
       await ctx.editMessageText(messageText, {
         reply_markup: keyboard.reply_markup,
         parse_mode: 'Markdown'
       });
+    } catch (editError) {
+      // Si impossible d'éditer (ex: message avec photo), supprimer et envoyer nouveau
+      try {
+        await ctx.deleteMessage();
+        await ctx.reply(messageText, {
+          reply_markup: keyboard.reply_markup,
+          parse_mode: 'Markdown'
+        });
+      } catch (deleteError) {
+        console.error('Erreur dans handler:', deleteError);
+        await ctx.answerCbQuery('❌ Erreur lors du chargement');
+      }
     }
     
     // Confirmer la callback pour éviter le loading
@@ -443,28 +437,24 @@ const handlePlugDetails = async (ctx, plugId, returnContext = 'top_plugs') => {
 
     const keyboard = createPlugKeyboard(plug, returnContext);
 
-    if (plug.image) {
-      try {
-        await ctx.editMessageMedia({
-          type: 'photo',
-          media: plug.image,
-          caption: message,
-          parse_mode: 'Markdown'
-        }, {
-          reply_markup: keyboard.reply_markup
-        });
-      } catch (error) {
-        console.error('Erreur envoi image plug:', error);
-        await ctx.editMessageText(message, {
-          reply_markup: keyboard.reply_markup,
-          parse_mode: 'Markdown'
-        });
-      }
-    } else {
+    // Toujours envoyer en texte pour éviter les erreurs d'images
+    try {
       await ctx.editMessageText(message, {
         reply_markup: keyboard.reply_markup,
         parse_mode: 'Markdown'
       });
+    } catch (editError) {
+      // Si impossible d'éditer (ex: message avec photo), supprimer et envoyer nouveau
+      try {
+        await ctx.deleteMessage();
+        await ctx.reply(message, {
+          reply_markup: keyboard.reply_markup,
+          parse_mode: 'Markdown'
+        });
+      } catch (deleteError) {
+        console.error('Erreur dans handler:', deleteError);
+        await ctx.answerCbQuery('❌ Erreur lors du chargement');
+      }
     }
   } catch (error) {
     console.error('Erreur dans handlePlugDetails:', error);

--- a/bot/src/handlers/plugsHandler.js
+++ b/bot/src/handlers/plugsHandler.js
@@ -18,51 +18,23 @@ const handleTopPlugs = async (ctx) => {
     
     const messageText = `${config?.botTexts?.topPlugsTitle || '🔌 Top Des Plugs'}\n\n${config?.botTexts?.topPlugsDescription || 'Choisissez une option pour découvrir nos plugs :'}`;
     
-    // Gestion intelligente du type de message (photo vs texte)
+    // Toujours envoyer en texte pour éviter les erreurs d'images
     try {
-      // D'abord essayer d'éditer comme message texte
       await ctx.editMessageText(messageText, {
         reply_markup: keyboard.reply_markup,
         parse_mode: 'Markdown'
       });
     } catch (editError) {
-      // Si c'est un message photo, utiliser editMessageMedia ou supprimer/renvoyer
-      if (editError.description && editError.description.includes('there is no text in the message to edit')) {
-        try {
-          // Essayer d'éditer comme média avec image
-          if (config?.welcome?.image) {
-            await ctx.editMessageMedia({
-              type: 'photo',
-              media: config.welcome.image,
-              caption: messageText,
-              parse_mode: 'Markdown'
-            }, {
-              reply_markup: keyboard.reply_markup
-            });
-          } else {
-            // Si pas d'image dans la config, supprimer et renvoyer
-            await ctx.deleteMessage();
-            await ctx.reply(messageText, {
-              reply_markup: keyboard.reply_markup,
-              parse_mode: 'Markdown'
-            });
-          }
-        } catch (mediaError) {
-          // Dernier recours : supprimer et renvoyer un nouveau message
-          try {
-            await ctx.deleteMessage();
-          } catch (deleteError) {
-            console.log('⚠️ Impossible de supprimer le message:', deleteError.message);
-          }
-          
-          await ctx.reply(messageText, {
-            reply_markup: keyboard.reply_markup,
-            parse_mode: 'Markdown'
-          });
-        }
-      } else {
-        // Autre type d'erreur, la relancer
-        throw editError;
+      // Si impossible d'éditer (ex: message avec photo), supprimer et envoyer nouveau
+      try {
+        await ctx.deleteMessage();
+        await ctx.reply(messageText, {
+          reply_markup: keyboard.reply_markup,
+          parse_mode: 'Markdown'
+        });
+      } catch (deleteError) {
+        console.error('Erreur dans handler:', deleteError);
+        await ctx.answerCbQuery('❌ Erreur lors du chargement');
       }
     }
     
@@ -139,28 +111,24 @@ const handleVipPlugs = async (ctx, page = 0) => {
     
     const messageText = `${config?.botTexts?.vipTitle || '👑 Boutiques VIP Premium'}\n\n${config?.botTexts?.vipDescription || '✨ Découvrez nos boutiques sélectionnées'}\n\n${paginationText} • ${vipPlugs.length} boutique${vipPlugs.length > 1 ? 's' : ''}`;
 
-    if (config?.welcome?.image) {
-      try {
-        await ctx.editMessageMedia({
-          type: 'photo',
-          media: config.welcome.image,
-          caption: messageText,
-          parse_mode: 'Markdown'
-        }, {
-          reply_markup: keyboard.reply_markup
-        });
-      } catch (error) {
-        // Fallback vers texte simple si l'image échoue
-        await ctx.editMessageText(messageText, {
-          reply_markup: keyboard.reply_markup,
-          parse_mode: 'Markdown'
-        });
-      }
-    } else {
+    // Toujours envoyer en texte pour éviter les erreurs d'images
+    try {
       await ctx.editMessageText(messageText, {
         reply_markup: keyboard.reply_markup,
         parse_mode: 'Markdown'
       });
+    } catch (editError) {
+      // Si impossible d'éditer (ex: message avec photo), supprimer et envoyer nouveau
+      try {
+        await ctx.deleteMessage();
+        await ctx.reply(messageText, {
+          reply_markup: keyboard.reply_markup,
+          parse_mode: 'Markdown'
+        });
+      } catch (deleteError) {
+        console.error('Erreur dans handler:', deleteError);
+        await ctx.answerCbQuery('❌ Erreur lors du chargement');
+      }
     }
 
     await ctx.answerCbQuery();
@@ -204,27 +172,24 @@ const handleAllPlugs = async (ctx, page = 0) => {
       message += `${paginationText}\n\n`;
     }
 
-    if (config.welcome?.image) {
-      try {
-        await ctx.editMessageMedia({
-          type: 'photo',
-          media: config.welcome.image,
-          caption: message,
-          parse_mode: 'Markdown'
-        }, {
-          reply_markup: keyboard.reply_markup
-        });
-      } catch (error) {
-        await ctx.editMessageText(message, {
-          reply_markup: keyboard.reply_markup,
-          parse_mode: 'Markdown'
-        });
-      }
-    } else {
+    // Toujours envoyer en texte pour éviter les erreurs d'images
+    try {
       await ctx.editMessageText(message, {
         reply_markup: keyboard.reply_markup,
         parse_mode: 'Markdown'
       });
+    } catch (editError) {
+      // Si impossible d'éditer (ex: message avec photo), supprimer et envoyer nouveau
+      try {
+        await ctx.deleteMessage();
+        await ctx.reply(message, {
+          reply_markup: keyboard.reply_markup,
+          parse_mode: 'Markdown'
+        });
+      } catch (deleteError) {
+        console.error('Erreur dans handler:', deleteError);
+        await ctx.answerCbQuery('❌ Erreur lors du chargement');
+      }
     }
     
     // Confirmer la callback pour éviter le loading


### PR DESCRIPTION
Refactor message editing in `plugsHandler.js` to prevent errors with image messages.

Previously, the bot would attempt to use `editMessageMedia` for messages with images. When this failed, it would then try `editMessageText` on a message that was originally an image, leading to "there is no text in the message to edit" errors. This PR unifies the logic to always attempt `editMessageText` first, and if that fails (e.g., on a photo message), it deletes the original message and sends a new text message, ensuring robust handling regardless of message type or image validity.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-9c75d0c4-b425-4885-818a-5b6a21b17fa4) · [Cursor](https://cursor.com/background-agent?bcId=bc-9c75d0c4-b425-4885-818a-5b6a21b17fa4)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)