### PR TITLE
Corriger l'URL du bouton du bot

### DIFF
--- a/bot/restore-config.js
+++ b/bot/restore-config.js
@@ -15,7 +15,7 @@ const WORKING_CONFIG = {
       {
         name: 'Telegram',
         emoji: '📱',
-        url: '@swissqualitysupport',
+        url: 'https://t.me/swissqualitysupport',
         order: 1
       },
       {
@@ -74,7 +74,7 @@ SwissQuality - La qualité suisse à votre service ! 🎯`,
   },
   
   socialMedia: {
-    telegram: '@swissqualitysupport',
+    telegram: 'https://t.me/swissqualitysupport',
     instagram: '',
     whatsapp: '',
     website: ''


### PR DESCRIPTION
Fix Telegram inline keyboard URL to a valid `https://t.me/` format to resolve 'Bad Request' error.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-09efa90b-9bb6-46d3-821e-d1417d7df039) · [Cursor](https://cursor.com/background-agent?bcId=bc-09efa90b-9bb6-46d3-821e-d1417d7df039)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)