### PR TITLE
Fix telegram bot start error

### DIFF
--- a/bot/src/handlers/startHandler.js
+++ b/bot/src/handlers/startHandler.js
@@ -117,11 +117,11 @@ const handleStart = async (ctx) => {
       // Continuer même si l'enregistrement utilisateur échoue
     }
 
-    // Obtenir la config
-    const config = await getConfigHelper();
+    // Obtenir la config mise à jour
+    const updatedConfig = await getConfigHelper();
     
     // NOUVEAU : Proposer directement les langues au /start
-    await showLanguageSelection(ctx, config);
+    await showLanguageSelection(ctx, updatedConfig);
     
   } catch (error) {
     console.error('❌ Erreur dans handleStart:', error);

--- a/bot/src/utils/translations.js
+++ b/bot/src/utils/translations.js
@@ -261,11 +261,11 @@ const translations = {
       de: 'Shops verfügbar'
     },
     'messages_activeUsers': {
-      fr: 'utilisateurs actifs',
-      en: 'active users',
-      it: 'utenti attivi',
-      es: 'usuarios activos',
-      de: 'aktive Benutzer'
+      fr: 'utilisateurs',
+      en: 'users',
+      it: 'utenti',
+      es: 'usuarios',
+      de: 'Benutzer'
     },
     'messages_availableShops': {
       fr: 'boutiques disponibles',
@@ -1467,11 +1467,11 @@ const translations = {
       de: 'Shops verfügbar'
     },
     'messages_activeUsers': {
-      fr: 'utilisateurs actifs',
-      en: 'active users',
-      it: 'utenti attivi',
-      es: 'usuarios activos',
-      de: 'aktive Benutzer'
+      fr: 'utilisateurs',
+      en: 'users',
+      it: 'utenti',
+      es: 'usuarios',
+      de: 'Benutzer'
     },
     'messages_availableShops': {
       fr: 'boutiques disponibles',


### PR DESCRIPTION
Fix `SyntaxError` by renaming a duplicate variable and update user count translation to reflect total users.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee2b7312-3a56-42af-878f-9c293fa0a741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee2b7312-3a56-42af-878f-9c293fa0a741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>